### PR TITLE
Add basic Vaultwarden support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,11 @@ Please open Issues and Pull Requests for any improvements or fixes!
 ---
 
 **Deploy powerful, vision-driven browser automations — now optimized for modern PaaS.**
+
+## Vaultwarden Compatibility
+
+This fork includes basic configuration for running against
+[Vaultwarden](https://github.com/dani-garcia/vaultwarden). Set
+`VAULTWARDEN_SERVER` and `VAULTWARDEN_SERVER_PORT` to point at your instance.
+Vaultwarden lacks Bitwarden's Vault Management API, so some functionality may
+not work. See `docs/vaultwarden-support.md` for details.

--- a/docs/vaultwarden-support.md
+++ b/docs/vaultwarden-support.md
@@ -1,0 +1,19 @@
+# Vaultwarden API Support
+
+Vaultwarden is an alternative server implementation of the Bitwarden API. The [project wiki](https://github.com/dani-garcia/vaultwarden/wiki) lists the following supported features:
+
+- Web interface equivalent to `https://vault.bitwarden.com/`
+- Personal and organization vaults, including groups, event logs, and password sharing
+- Collections, file attachments, folders, favorites, website icons, and Bitwarden Authenticator (TOTP)
+- Bitwarden Send, Emergency Access, live sync via WebSocket, trash, and master password re-prompt
+- Personal API key and two-step login methods (email, Duo, YubiKey, FIDO2)
+- Username generator integrations and Directory Connector support
+- Admin Password Reset and various enterprise policies
+
+The wiki also describes features missing from Vaultwarden compared to the official server:
+
+- Bitwarden Public API / Organization API key (only partial support for Directory Connector)
+- Single Sign-On (SSO) and custom roles
+- Certain enterprise policies such as requiring SSO authentication, vault timeout, and removing individual vault export
+
+Vaultwarden does not mention support for the Bitwarden Vault Management API. The current codebase relies on that API, so some functionality may not work when switching to Vaultwarden.

--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -263,6 +263,8 @@ class Settings(BaseSettings):
 
     BITWARDEN_SERVER: str = "http://localhost"
     BITWARDEN_SERVER_PORT: int = 8002
+    VAULTWARDEN_SERVER: str | None = None
+    VAULTWARDEN_SERVER_PORT: int | None = None
 
     SVG_MAX_LENGTH: int = 100000
 

--- a/skyvern/forge/sdk/services/bitwarden.py
+++ b/skyvern/forge/sdk/services/bitwarden.py
@@ -28,7 +28,10 @@ from skyvern.forge.sdk.schemas.credentials import (
 )
 
 LOG = structlog.get_logger()
-BITWARDEN_SERVER_BASE_URL = f"{settings.BITWARDEN_SERVER}:{settings.BITWARDEN_SERVER_PORT or 8002}"
+if settings.VAULTWARDEN_SERVER:
+    BITWARDEN_SERVER_BASE_URL = f"{settings.VAULTWARDEN_SERVER}:{settings.VAULTWARDEN_SERVER_PORT or 8000}"
+else:
+    BITWARDEN_SERVER_BASE_URL = f"{settings.BITWARDEN_SERVER}:{settings.BITWARDEN_SERVER_PORT or 8002}"
 
 
 class BitwardenItemType(IntEnum):


### PR DESCRIPTION
## Summary
- support Vaultwarden by adding new configuration variables
- prefer Vaultwarden server URLs when set
- document Vaultwarden compatibility and feature gaps

## Testing
- `pre-commit run --all-files` *(fails: ShellCheck - Executable `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876e98b8638832c8544a938edde3e89